### PR TITLE
feat: add support for custom reporters in CLI and configuration

### DIFF
--- a/.changeset/clear-clocks-ask.md
+++ b/.changeset/clear-clocks-ask.md
@@ -1,0 +1,10 @@
+---
+"@viteval/core": patch
+"@viteval/cli": patch
+---
+
+feat: add CLI support for custom file reporters and configurable outputs
+
+```bash
+viteval run --reporters ./src/reporters/voltops-reporter.ts
+```

--- a/docs/guide/advanced/reporters.md
+++ b/docs/guide/advanced/reporters.md
@@ -53,4 +53,22 @@ viteval run --reporters default file
 ## Custom Reporters
 
 > [!CAUTION]
-> Custom reporters are not yet supported, if interested please let us know by [creating an issue](https://github.com/viteval/viteval/issues/new).
+## Custom reporters
+
+You can point Viteval to any Vitest-compatible reporter module. When you pass a relative path it will be resolved against your project root:
+
+```ts title="viteval.config.ts"
+import { defineConfig } from 'viteval/config';
+
+export default defineConfig({
+  reporters: ['./src/reporters/voltops-reporter.ts'],
+});
+```
+
+Or via the CLI:
+
+```bash
+viteval run --reporters ./src/reporters/voltops-reporter.ts
+```
+
+You can also supply a package name (for example `@acme/viteval-reporter`) after installing it in your project.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -22,7 +22,11 @@ export interface VitevalProviderConfig {
 // };
 
 // TODO: Add support via the config file for reporter
-export type VitevalReporter = 'default' | 'json' | 'file'; // | VitevalReporterBraintrust;
+export type VitevalReporter =
+  | 'default'
+  | 'json'
+  | 'file'
+  | (string & {}); // custom reporter module path or name
 
 /**
  * Viteval configuration.


### PR DESCRIPTION
- Added file-based reporter support to the CLI run command so --reporters file emits JSON output.
- Made reporter output paths configurable via `--outputPath`, including automatic `<timestamp>` substitution.
- Updated the Yargs builder to align argument types with the EvalOptions interface.